### PR TITLE
Disable acp lock for all type scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ contracts/c/build/*
 build/*
 !.gitkeep
 .tmp/
+.idea/
 
 migrations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2924,7 +2924,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "ckb-testtool",
  "ckb-tool",

--- a/contracts/class-type/Cargo.toml
+++ b/contracts/class-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "class-type"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 [dependencies]

--- a/contracts/issuer-type/Cargo.toml
+++ b/contracts/issuer-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "issuer-type"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 [dependencies]

--- a/contracts/nft-type/Cargo.toml
+++ b/contracts/nft-type/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nft-type"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 [dependencies]

--- a/contracts/nft-type/src/validator.rs
+++ b/contracts/nft-type/src/validator.rs
@@ -92,10 +92,9 @@ pub fn validate_nft_ext_info(
         if input_nft.is_locked() {
             return Err(Error::LockedNFTCannotAddExtInfo);
         }
-    } else {
-        if input_len != output_len {
-            return Err(Error::NFTExtInfoLenError);
-        }
+    } else if input_len != output_len {
+        return Err(Error::NFTExtInfoLenError);
     }
+
     Ok(())
 }

--- a/contracts/script-utils/Cargo.toml
+++ b/contracts/script-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "script-utils"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 [dependencies]

--- a/contracts/script-utils/src/error.rs
+++ b/contracts/script-utils/src/error.rs
@@ -42,7 +42,7 @@ pub enum Error {
     LockedNFTCannotAddExtInfo,
     LockedNFTCannotDestroy,
     LockedNFTCannotUpdateCharacteristic,
-    FirstInputWitnessNoneError,
+    GroupInputWitnessNoneError = 40,
 }
 
 impl From<SysError> for Error {

--- a/contracts/script-utils/src/helper.rs
+++ b/contracts/script-utils/src/helper.rs
@@ -121,11 +121,16 @@ pub fn cell_deps_and_inputs_have_issuer_or_class_lock(nft_args: &Bytes) -> Resul
     Ok(false)
 }
 
-pub fn check_first_input_witness_is_none() -> Result<bool, Error> {
-    match load_witness_args(0, Source::Input) {
-        Ok(witness_args) => Ok(witness_args.lock().to_opt().is_none()),
-        Err(_) => Ok(true),
-    }
+pub fn check_group_input_witness_is_none_with_type(type_script: &Script) -> Result<bool, Error> {
+    let lock_script: Script = QueryIter::new(load_cell_type, Source::Input)
+        .position(|type_opt| type_opt.map_or(false, |type_| type_.as_slice() == type_script.as_slice()))
+        .map(|index| load_cell_lock(index, Source::Input).map_or(Err(Error::Encoding), Ok))
+        .map_or_else(|| Err(Error::Encoding), |lock_| lock_)?;
+
+    QueryIter::new(load_cell_lock, Source::Input)
+        .position(|lock| lock.as_slice() == lock_script.as_slice())
+        .map(|index| load_witness_args(index, Source::Input).map_or_else(|_| Ok(true), |witness_args| Ok(witness_args.lock().to_opt().is_none())))
+        .map_or_else(|| Err(Error::Encoding), |result_| result_)
 }
 
 pub fn parse_dyn_vec_len(data: &[u8]) -> usize {

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tests"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
- Find the lock script(lock1) according to the  NFT `type scripts`
- Load the first witness_args of the group inputs whose lock scripts are the same as lock1
- If the `witness_args.lock` is none, throw contract error and stop the contract